### PR TITLE
adding requirements.txt and python docker file

### DIFF
--- a/plearn-api/Dockerfile
+++ b/plearn-api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:2.7.11-onbuild
+RUN python setup.py install
+EXPOSE 6543
+CMD ["/usr/local/bin/pserve", "plearn_api.ini", "--reload"]
+

--- a/plearn-api/requirements.txt
+++ b/plearn-api/requirements.txt
@@ -1,0 +1,13 @@
+cornice==1.2.1
+passlib==1.6.5
+PasteDeploy==1.5.2
+pyramid==1.7a1
+repoze.lru==0.6
+simplejson==3.8.2
+translationstring==1.3
+venusian==1.0
+waitress==0.9.0
+WebOb==1.6.0
+wheel==0.26.0
+zope.deprecation==4.1.2
+zope.interface==4.1.3


### PR DESCRIPTION
You should be able to build container like so:

```bash
$ cd <project root>
$ docker build plearn-api
```

Then you should be able to run like this:
```bash
$ docker run -t -i -p 127.0.0.1:9999:6543 08834e4bb087 bash
root@container-id:/usr/src/app# pserve plearn_api.ini --reload
Starting subprocess with file monitor
Starting server in PID 11.
serving on http://0.0.0.0:6543
```

So at that point it's running on the docker container.  Not sure how to actually make docker expose that to the outside world...  It's a start though!